### PR TITLE
new 1.8 version

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ test:
   commands:
     - pip check
     #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
-    - pytest tests/test.py
+    #test.py failing https://github.com/MicroPyramid/forex-python/issues/148
+    # - pytest
   
 about:
   home: https://github.com/MicroPyramid/forex-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "forex-python" %}
+{% set version = "1.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/MicroPyramid/forex-python/archive/v{{ version }}.tar.gz
+  sha256: 062adc6380b9ac49168a2b89faba2fa60fa5806175da61230b121f139c9c4ab5
+
+build:
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - wheel
+    - setuptools
+
+  run:
+    - python
+    - requests
+    - simplejson
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest
+    - requests
+  imports:
+    - forex_python
+  commands:
+    - pip check
+    #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
+    - pytest tests/test.py
+  
+about:
+  home: https://github.com/MicroPyramid/forex-python
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Forex Python is a Free Foreign exchange rates and currency conversion.
+  description: |
+    Free Foreign exchange rates, bitcoin prices and currency conversion, providing following features 
+    - List all currency rates. 
+    - BitCoin price for all curuncies.
+    - Converting amount to BitCoins.
+    - Get historical rates for any day since 1999.
+    - Conversion rate for one currency(ex; USD to INR).
+    - Convert amount from one currency to other.(‘USD 10$’ to INR)
+    - Currency Symbols
+    - Currency names
+
+  dev_url: https://github.com/MicroPyramid/forex-python
+  doc_url: https://forex-python.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - markw77

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/MicroPyramid/forex-python/archive/v{{ version }}.tar.gz
-  sha256: 062adc6380b9ac49168a2b89faba2fa60fa5806175da61230b121f139c9c4ab5
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7d4a5c36b66e7ef9ee515f607a41249a1ae1a2499a9e011702b66f784325cc76
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
@@ -26,19 +26,16 @@ requirements:
     - simplejson
 
 test:
-  source_files:
-    - tests
   requires:
     - pip
     - pytest
-    - requests
   imports:
     - forex_python
   commands:
     - pip check
     #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
     #test.py failing https://github.com/MicroPyramid/forex-python/issues/148
-    # - pytest
+    - pytest || true
   
 about:
   home: https://github.com/MicroPyramid/forex-python


### PR DESCRIPTION
forex python 1.8 for snowflake
- [upstream](https://github.com/MicroPyramid/forex-python)
- execute only test.py as bitcoin_test.py failing [issue](https://github.com/MicroPyramid/forex-python/issues/147), cannot do otherwise skipping only test_bitcooin.py for some reason

! Tried 1.6 version which according to readme should work: https://github.com/AnacondaRecipes/forex-python-feedstock/pull/2
however it does not, **agreed with snowflake that if earlier version does not work we would deliver the latest even though test are failing** 
