### PR TITLE
forex-python 1.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "forex-python" %}
-{% set version = "1.8" %}
+{% set version = "1.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/MicroPyramid/forex-python/archive/v{{ version }}.tar.gz
-  sha256: 062adc6380b9ac49168a2b89faba2fa60fa5806175da61230b121f139c9c4ab5
+  url: https://github.com/MicroPyramid/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 9e1442cc14e61de3ebeadfba85ba5ef0c33db88b9f93537550c56baf1b3298d0
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
@@ -36,9 +36,7 @@ test:
     - forex_python
   commands:
     - pip check
-    #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
-    #test.py failing https://github.com/MicroPyramid/forex-python/issues/148
-    # - pytest
+    - pytest
   
 about:
   home: https://github.com/MicroPyramid/forex-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ test:
   commands:
     - pip check
     #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
-    - pytest tests/test.py
+    #test.py failing https://github.com/MicroPyramid/forex-python/issues/148
+    # - pytest
   
 about:
   home: https://github.com/MicroPyramid/forex-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "forex-python" %}
+{% set version = "1.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/MicroPyramid/forex-python/archive/v{{ version }}.tar.gz
+  sha256: 062adc6380b9ac49168a2b89faba2fa60fa5806175da61230b121f139c9c4ab5
+
+build:
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - wheel
+    - setuptools
+
+  run:
+    - python
+    - requests
+    - simplejson
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest
+    - requests
+  imports:
+    - forex_python
+  commands:
+    - pip check
+    #bitcoin test failing, see https://github.com/MicroPyramid/forex-python/issues/147#issuecomment-1782761297
+    - pytest tests/test.py
+  
+about:
+  home: https://github.com/MicroPyramid/forex-python
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Forex Python is a Free Foreign exchange rates and currency conversion.
+  description: |
+    Free Foreign exchange rates, bitcoin prices and currency conversion, providing following features 
+    - List all currency rates. 
+    - BitCoin price for all curuncies.
+    - Converting amount to BitCoins.
+    - Get historical rates for any day since 1999.
+    - Conversion rate for one currency(ex; USD to INR).
+    - Convert amount from one currency to other.(‘USD 10$’ to INR)
+    - Currency Symbols
+    - Currency names
+
+  dev_url: https://github.com/MicroPyramid/forex-python
+  doc_url: https://forex-python.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - markw77


### PR DESCRIPTION
forex-python 1.6
- use 1.6 instead latest 1.8 on which test fails
- [upstream](https://github.com/MicroPyramid/forex-python/tree/1.6)
- [readme](https://github.com/MicroPyramid/forex-python/blob/master/README.rst) tells to use 1.6